### PR TITLE
Add internal data structure

### DIFF
--- a/InfluxUploader.php
+++ b/InfluxUploader.php
@@ -52,13 +52,15 @@ function escapeInfluxTagValue($str) {
  *   - provider: string
  *   - vpn-servers: array, each entry consisting of:
  *     - name: string
- *     - addresses: array with single entry:
- *       - entry 0 must be an array with two entries:
- *         - ipv4: integer (0 or 1)
- *         - ipv6: integer (0 or 1)
- *     - dns: same format as "addresses"
- *     - ntp: same format as "addresses"
- *     - uplink: same format as "addresses"
+ *     - status: array
+ *       - addresses: array, with two entries:
+ *         - ipv4: array, with one entry:
+ *           - up: boolean
+ *         - ipv6: array, with one entry:
+ *           - up: boolean
+ *       - dns: same format as "addresses"
+ *       - ntp: same format as "addresses"
+ *       - uplink: same format as "addresses"
  *
  * @param $influxConfig Configuration settings for connecting to InfluxDB.
  *   Must be an array with the following keys:
@@ -84,7 +86,7 @@ function uploadToInfluxDB($report, $influxConfig) {
     foreach (array('ntp', 'addresses', 'dns', 'uplink') as $topic) {
       foreach (array('ipv4', 'ipv6') as $addrType) {
         $value = '0.0';
-        if ($serverState[$topic][0][$addrType]) {
+        if ($serverState['status'][$topic][$addrType]['up']) {
           $value = '1.0';
         }
         $uploadText .= "${topic}.$addrType=$value,";

--- a/app.js
+++ b/app.js
@@ -37,23 +37,21 @@ $(function() {
 
         // Iterate over services returned by gatemon
         counter = 0;
-        for (var key in vpnserver_data) {
-          // Check if item is an array
-          if (Object.prototype.toString.call(vpnserver_data[key]) === '[object Array]') {
-            counter++;
-            if (gatemon_counter <= 1) {
-              $('<td colspan="2" class="text-center">' + key + '</td>').appendTo($('#' + vpnserver_name + 'services'));
-              $('<td class="text-center">IPv4</td><td class="text-center">IPv6</td>').appendTo($('#' + vpnserver_name + 'servicesfamily'));
-            }
-
-            $.each(['ipv4', 'ipv6'], function() {
-              if (vpnserver_data[key][0][this]) {
-                $('<td class="good"></td>').appendTo($('#' + vpnserver_name + gatemon['uuid']));
-              } else {
-                $('<td class="bad"></td>').appendTo($('#' + vpnserver_name + gatemon['uuid']));
-              }
-            });
+        var vpnserver_status = vpnserver_data['status'];
+        for (var key in vpnserver_status) {
+          counter++;
+          if (gatemon_counter <= 1) {
+            $('<td colspan="2" class="text-center">' + key + '</td>').appendTo($('#' + vpnserver_name + 'services'));
+            $('<td class="text-center">IPv4</td><td class="text-center">IPv6</td>').appendTo($('#' + vpnserver_name + 'servicesfamily'));
           }
+
+          $.each(['ipv4', 'ipv6'], function() {
+            if (vpnserver_status[key][this]['up']) {
+              $('<td class="good"></td>').appendTo($('#' + vpnserver_name + gatemon['uuid']));
+            } else {
+              $('<td class="bad"></td>').appendTo($('#' + vpnserver_name + gatemon['uuid']));
+            }
+          });
         }
 
         if (gatemon_counter <= 1) {

--- a/put.php
+++ b/put.php
@@ -64,23 +64,19 @@ function sanitizeYamlJsonInput ($report_decoded) {
 
   // Create sanitized report structure (using internal format)
   $newReport = array(
-    'version' => 0.1,
+    'version' => $report_decoded['version'] ?? '0.1',
     // Overwrite lastupdated with servers time to make timestamps comparable
     'lastupdated' => date(DateTime::ISO8601),
     'uuid' => $report_decoded['uuid'],
-    'name' => $report_decoded['name'],
-    'provider' => $report_decoded['provider'],
+    'name' => $report_decoded['name'] ?? 'unknown',
+    'provider' => $report_decoded['provider'] ?? 'unknown',
     'vpn-servers' => array(),
   );
-
-  // Set version if transmitted from node
-  if (isset($report_decoded['version']))
-    $newReport['version'] = $report_decoded['version'];
 
   // Copy reported data for each server
   foreach ($report_decoded['vpn-servers'] as $reportedServerData) {
     $newServerData = array(
-      'name' => $reportedServerData['name'],
+      'name' => $reportedServerData['name'] ?? 'unknown',
       'status' => array(),
     );
 


### PR DESCRIPTION
Hier ist ein Vorschlag, wie eine interne Datenstruktur für gatemon-html aussehen könnte. Damit ist das Datenformat in merged.json (das auf der Webseite angezeigt wird) unabhängig von dem Datenformat, das von den Gatemons geliefert wird.

Wenn einige Gatemons in Zukunft zusätzliche Infos liefern sollen, kann man im diese im internen Format einfach hinzufügen. Bei alten Gatemons, die diese Infos dann noch nicht liefern, kann man diese Werte im internen Format leer lassen.

Solche Werte (Latenz, Paketverlust...) könnten parallel zum "up"-Feld eingebaut werden.

Dieser ganze PR dürfte keine sichtbaren Auswirkungen auf der Webseite haben, sondern nur die interne Verarbeitung und den Inhalt von `data/*.json` verändern.