### PR TITLE
Show Gatemon client details in separate table

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,16 +30,23 @@ $(function() {
       + '</tr>'
       + '</thead>').appendTo($('#lastupdated'));
 
+    // Gatemon reports older than 2 hours are marked as bad:
+    var oldestAllowedTimestamp = Date.now() - (2*60*60*1000);
+
     // Iterate over gatemons
     data.forEach(function(gatemon) {
       // Increment counter
       gatemon_counter++;
 
+      gatemon_class = "";
+      if (Date.parse(gatemon['lastupdated']) < oldestAllowedTimestamp)
+        gatemon_class = "outdated";
+
       $('<tr>'
         + '<td>' + gatemon['name'] + '</td>'
         + '<td>' + gatemon['provider'] + '</td>'
         + '<td>' + gatemon['version'] + '</td>'
-        + '<td><time class="timeago" datetime="' + gatemon['lastupdated'] + '">' + gatemon['lastupdated'] + '</time></td>'
+        + '<td class="' + gatemon_class + '"><time class="timeago" datetime="' + gatemon['lastupdated'] + '">' + gatemon['lastupdated'] + '</time></td>'
         + '</tr>').appendTo($('#lastupdated'));
       $(".timeago").timeago();
 
@@ -53,7 +60,7 @@ $(function() {
           $('<div class="col-lg-6 col-md-12"><div class="well"><table class="table" id="' + vpnserver_name + '"><thead><tr id="' + vpnserver_name + 'server"></tr><tr id="' + vpnserver_name + 'services"><td></td></tr><tr id="' + vpnserver_name + 'servicesfamily"><td></td></tr></thead><tbody></tbody></table></div></div>').appendTo($('#content'));
         }
 
-        $('<tr id="' + vpnserver_name + gatemon['uuid'] + '"><td title="Name: ' + gatemon['name'] + '\nProvider: ' + gatemon['provider'] + '\nVersion: ' + gatemon['version'] + '\nZuletzt aktualisiert: ' + gatemon['lastupdated'] + '">' + gatemon['name'] + '</td></tr>').appendTo($('#' + vpnserver_name + ' tbody'));
+        $('<tr id="' + vpnserver_name + gatemon['uuid'] + '"><td class="' + gatemon_class + '" title="Name: ' + gatemon['name'] + '\nProvider: ' + gatemon['provider'] + '\nVersion: ' + gatemon['version'] + '\nZuletzt aktualisiert: ' + gatemon['lastupdated'] + '">' + gatemon['name'] + '</td></tr>').appendTo($('#' + vpnserver_name + ' tbody'));
 
         // Iterate over services returned by gatemon
         counter = 0;

--- a/app.js
+++ b/app.js
@@ -21,12 +21,26 @@ $(function() {
     // Reset counter for array
     gatemon_counter = 0;
 
+    $('<thead>'
+      +'<tr>'
+      + '<th>Gatemon Name</th>'
+      + '<th>Provider</th>'
+      + '<th>Version</th>'
+      + '<th>Last Update</time></th>'
+      + '</tr>'
+      + '</thead>').appendTo($('#lastupdated'));
+
     // Iterate over gatemons
     data.forEach(function(gatemon) {
       // Increment counter
       gatemon_counter++;
 
-      $('<tr><td>' + gatemon['provider'] + '</td><td> <time class="timeago" datetime="' + gatemon['lastupdated'] + '">' + gatemon['lastupdated'] + '</time></td></tr>').appendTo($('#lastupdated'));
+      $('<tr>'
+        + '<td>' + gatemon['name'] + '</td>'
+        + '<td>' + gatemon['provider'] + '</td>'
+        + '<td>' + gatemon['version'] + '</td>'
+        + '<td><time class="timeago" datetime="' + gatemon['lastupdated'] + '">' + gatemon['lastupdated'] + '</time></td>'
+        + '</tr>').appendTo($('#lastupdated'));
       $(".timeago").timeago();
 
       // Iterate over gatemon data

--- a/app.js
+++ b/app.js
@@ -23,6 +23,8 @@ $(function() {
       // Increment counter
       gatemon_counter++;
 
+      $('<tr><td>' + gatemon['provider'] + '</td><td> <time class="timeago" datetime="' + gatemon['lastupdated'] + '">' + gatemon['lastupdated'] + '</time></td></tr>').appendTo($('#lastupdated'));
+
       // Iterate over gatemon data
       gatemon['vpn-servers'].forEach(function(vpnserver_data) {
         // Short VPN hostname

--- a/app.js
+++ b/app.js
@@ -13,6 +13,9 @@ $(function() {
     dataType: 'json'
   });
 
+  $.timeago.settings.allowFuture = true;
+  $.timeago.settings.allowPast = true;
+
   // Parse response
   function parseResponse(data) {
     // Reset counter for array
@@ -24,6 +27,7 @@ $(function() {
       gatemon_counter++;
 
       $('<tr><td>' + gatemon['provider'] + '</td><td> <time class="timeago" datetime="' + gatemon['lastupdated'] + '">' + gatemon['lastupdated'] + '</time></td></tr>').appendTo($('#lastupdated'));
+      $(".timeago").timeago();
 
       // Iterate over gatemon data
       gatemon['vpn-servers'].forEach(function(vpnserver_data) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
         "twbs/bootstrap": "^3.3",
-        "components/jquery": "^2.2"
+        "components/jquery": "^2.2",
+        "rmm5t/jquery-timeago": "^1.5"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f32d0636e3d6571d3744e293a65f200f",
-    "content-hash": "9251affea9b9a67a1703dff3ef5c24f1",
+    "content-hash": "0cb19ae0af91c68b8eb15418e391cb70",
     "packages": [
         {
             "name": "components/jquery",
-            "version": "2.2.1",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/components/jquery.git",
-                "reference": "7894addbce3c4de6f82449610e6f8e168b49e9b0"
+                "reference": "981036fcb56668433a7eb0d1e71190324b4574df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/components/jquery/zipball/7894addbce3c4de6f82449610e6f8e168b49e9b0",
-                "reference": "7894addbce3c4de6f82449610e6f8e168b49e9b0",
+                "url": "https://api.github.com/repos/components/jquery/zipball/981036fcb56668433a7eb0d1e71190324b4574df",
+                "reference": "981036fcb56668433a7eb0d1e71190324b4574df",
                 "shasum": ""
             },
             "type": "component",
@@ -47,20 +46,66 @@
             ],
             "description": "jQuery JavaScript Library",
             "homepage": "http://jquery.com",
-            "time": "2016-02-24 08:16:25"
+            "time": "2016-05-25T06:43:59+00:00"
         },
         {
-            "name": "twbs/bootstrap",
-            "version": "v3.3.6",
+            "name": "rmm5t/jquery-timeago",
+            "version": "v1.5.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/twbs/bootstrap.git",
-                "reference": "81df608a40bf0629a1dc08e584849bb1e43e0b7a"
+                "url": "https://github.com/rmm5t/jquery-timeago.git",
+                "reference": "180864a9c544a49e43719b457250af216d5e4c3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twbs/bootstrap/zipball/81df608a40bf0629a1dc08e584849bb1e43e0b7a",
-                "reference": "81df608a40bf0629a1dc08e584849bb1e43e0b7a",
+                "url": "https://api.github.com/repos/rmm5t/jquery-timeago/zipball/180864a9c544a49e43719b457250af216d5e4c3a",
+                "reference": "180864a9c544a49e43719b457250af216d5e4c3a",
+                "shasum": ""
+            },
+            "require": {
+                "components/jquery": ">=1.2.3"
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "scripts": [
+                        "jquery.timeago.js"
+                    ],
+                    "files": [
+                        "locales/jquery.timeago.*.js"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ryan McGeary",
+                    "email": "ryan@mcgeary.org"
+                }
+            ],
+            "description": "jQuery plugin that makes it easy to support automatically updating fuzzy timestamps (e.g. \"4 minutes ago\" or \"about 1 day ago\").",
+            "homepage": "http://timeago.yarp.com/",
+            "keywords": [
+                "microformat",
+                "time"
+            ],
+            "time": "2017-01-19T18:07:14+00:00"
+        },
+        {
+            "name": "twbs/bootstrap",
+            "version": "v3.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twbs/bootstrap.git",
+                "reference": "0b9c4a4007c44201dce9a6cc1a38407005c26c86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twbs/bootstrap/zipball/0b9c4a4007c44201dce9a6cc1a38407005c26c86",
+                "reference": "0b9c4a4007c44201dce9a6cc1a38407005c26c86",
                 "shasum": ""
             },
             "replace": {
@@ -98,7 +143,7 @@
                 "responsive",
                 "web"
             ],
-            "time": "2015-11-24 19:37:05"
+            "time": "2016-07-25T15:51:55+00:00"
         }
     ],
     "packages-dev": [],

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
     </div>
 
     <script src="/vendor/components/jquery/jquery.min.js"></script>
+    <script src="vendor/rmm5t/jquery-timeago/jquery.timeago.js"></script>
+    <script src="vendor/rmm5t/jquery-timeago/locales/jquery.timeago.de.js"></script>
     <script src="/app.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,11 +14,14 @@
       <div class="row">
         <div class="col-sm-12">
           <h1>Freifunk Bremen Status</h1>
-          <div class="col-sm-12"><table class="table" id="lastupdated"></table></div>
         </div>
       </div>
 
       <div class="row" id="content"></div>
+
+      <div class="col-sm-12">
+        <table class="table" id="lastupdated"></table>
+      </div>
     </div>
 
     <script src="/vendor/components/jquery/jquery.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <div class="row">
         <div class="col-sm-12">
           <h1>Freifunk Bremen Status</h1>
+          <div class="col-sm-12"><table class="table" id="lastupdated"></table></div>
         </div>
       </div>
 

--- a/style.css
+++ b/style.css
@@ -15,6 +15,9 @@ td.bad  {
   border-right: 1px solid #f5f5f5;
   border-left: 1px solid #f5f5f5;
 }
+td.outdated  {
+  color: red;
+}
 table {
   margin: 0;
 }


### PR DESCRIPTION
Das hier sind die Änderungen von https://github.com/freifunkh/gatemon-html, sowie ein paar Erweiterungen obendrauf. Damit sieht man die ganzen Details aus dem Gatemon-Tooltip in einer separaten Tabelle. Außerdem werden Gatemons, die seit zwei Stunden kein Update geschickt haben, rot markiert.